### PR TITLE
Setup node to add optional static peer when running

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ cd $GOPATH/bin
 Run two nodes in different ports and use enode url to connect.  
 First terminal
 ```
-./conceptchain --addr :3000
+./conceptchain --addr :3000 --name node1
 ```
-Second terminal
+Second terminal, set peer args as the enode url displayed in first terminal
 ```
- ./conceptchain --addr :30001 --peer enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:3000
+./conceptchain --addr :30001 --name node2 --peer enode://4b7f6c7274881a6c7fd3068c1a147d3e9d003a964c3e3490814942dd7cbb975e0424db335881962239dd8170a9cc5b09a9f4c81babd57ac10df0d6465a58dd67@[::]:3000
 ```

--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ go install
 cd $GOPATH/bin
 ./conceptchain
 ```
+
+# Test p2p connection
+Run two nodes in different ports and use enode url to connect.  
+First terminal
+```
+./conceptchain --addr :3000
+```
+Second terminal
+```
+ ./conceptchain --addr :30001 --peer enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:3000
+```

--- a/main.go
+++ b/main.go
@@ -1,19 +1,19 @@
 package main
 
 import (
+	"conceptchain/node"
 	"fmt"
 )
 
 func main() {
-	n, err := NewNode("node1")
+	n, err := node.NewNode("node1")
 
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	n.start()
-	//fmt.Println(n.server.PeerCount())
-	// FIXME: need to initialize server config for this, currently null pointer
-	// fmt.Println(n.server.PeerCount())
-	n.stop()
+	n.Start()
+	fmt.Println(n.server.PeerCount())
+	fmt.Println(n.Server.Peers())
+	n.Stop()
 }

--- a/main.go
+++ b/main.go
@@ -12,9 +12,12 @@ func main() {
 	// setup log to stdout.
 	handler := log.StreamHandler(os.Stdout, log.TerminalFormat(false))
 	log.Root().SetHandler(handler)
+	logger := log.New()
 
 	// args
 	listenAddr := flag.String("addr", ":30301", "listen address")
+	peerUrl := flag.String("peer", "", "enode URL of static peer")
+
 	flag.Parse()
 
 	config := &node.DefaultConfig
@@ -23,11 +26,20 @@ func main() {
 	n, err := node.NewNode(config)
 
 	if err != nil {
-		fmt.Println(err)
+		logger.Error("Cannot create node", "err", err)
 		return
 	}
+
 	n.Start()
-	fmt.Println(n.Server.Peers())
+
+	if *peerUrl != "" {
+		success, err := n.AddPeer(*peerUrl)
+		if !success {
+			logger.Error("Fail to add peer", "err", err, "peerUrl", peerUrl)
+		}
+	}
+
+	fmt.Println(n.Server().Peers())
 	blockForever()
 }
 

--- a/main.go
+++ b/main.go
@@ -3,17 +3,15 @@ package main
 import (
 	"conceptchain/node"
 	"fmt"
-	"github.com/ethereum/go-ethereum/log"
+	"conceptchain/log"
 	"os"
 	"flag"
 )
 
 func main() {
-	// setup max log verbosity.
-	logger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
-	logger.Verbosity(log.Lvl(6))
-	logger.Vmodule("")
-	log.Root().SetHandler(logger)
+	// setup log to stdout.
+	handler := log.StreamHandler(os.Stdout, log.TerminalFormat(false))
+	log.Root().SetHandler(handler)
 
 	// args
 	listenAddr := flag.String("addr", ":30301", "listen address")

--- a/main.go
+++ b/main.go
@@ -6,14 +6,13 @@ import (
 )
 
 func main() {
-	n, err := node.NewNode("node1")
+	n, err := node.NewNode(&node.DefaultConfig)
 
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	n.Start()
-	fmt.Println(n.server.PeerCount())
 	fmt.Println(n.Server.Peers())
 	n.Stop()
 }

--- a/main.go
+++ b/main.go
@@ -3,10 +3,26 @@ package main
 import (
 	"conceptchain/node"
 	"fmt"
+	"github.com/ethereum/go-ethereum/log"
+	"os"
+	"flag"
 )
 
 func main() {
-	n, err := node.NewNode(&node.DefaultConfig)
+	// setup max log verbosity.
+	logger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
+	logger.Verbosity(log.Lvl(6))
+	logger.Vmodule("")
+	log.Root().SetHandler(logger)
+
+	// args
+	listenAddr := flag.String("addr", ":30301", "listen address")
+	flag.Parse()
+
+	config := &node.DefaultConfig
+	config.P2P.ListenAddr = *listenAddr
+
+	n, err := node.NewNode(config)
 
 	if err != nil {
 		fmt.Println(err)
@@ -14,5 +30,9 @@ func main() {
 	}
 	n.Start()
 	fmt.Println(n.Server.Peers())
-	n.Stop()
+	blockForever()
+}
+
+func blockForever() {
+	select{ }
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"conceptchain/node"
-	"fmt"
 	"conceptchain/log"
-	"os"
+	"conceptchain/node"
 	"flag"
+	"fmt"
+	"os"
+	"time"
 )
 
 func main() {
@@ -17,11 +18,13 @@ func main() {
 	// args
 	listenAddr := flag.String("addr", ":30301", "listen address")
 	peerUrl := flag.String("peer", "", "enode URL of static peer")
+	name := flag.String("name", "", "Name of node")
 
 	flag.Parse()
 
 	config := &node.DefaultConfig
 	config.P2P.ListenAddr = *listenAddr
+	config.Name = *name
 
 	n, err := node.NewNode(config)
 
@@ -39,10 +42,19 @@ func main() {
 		}
 	}
 
-	fmt.Println(n.Server().Peers())
+	go displayPeers(n)
+
 	blockForever()
 }
 
+func displayPeers(n *node.Node) {
+	for {
+		fmt.Println("Peer list: ", n.Server().PeerCount())
+		time.Sleep(10 * time.Second)
+	}
+
+}
+
 func blockForever() {
-	select{ }
+	select {}
 }

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -26,7 +26,7 @@ var DefaultConfig = NodeConfig{
 	//WSModules:        []string{"net", "web3"},
 	P2P: p2p.Config{
 		ListenAddr: ":30303",
-		MaxPeers:   25,
+		MaxPeers:   5,
 		NAT:        nat.Any(),
 	},
 }

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -1,0 +1,56 @@
+package node
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"conceptchain/p2p"
+	"conceptchain/p2p/nat"
+)
+
+const (
+	DefaultHTTPHost = "localhost" // Default host interface for the HTTP RPC server
+	DefaultHTTPPort = 8545        // Default TCP port for the HTTP RPC server
+	DefaultWSHost   = "localhost" // Default host interface for the websocket RPC server
+	DefaultWSPort   = 8546        // Default TCP port for the websocket RPC server
+)
+
+// DefaultConfig contains reasonable default settings.
+var DefaultConfig = NodeConfig{
+	DataDir: DefaultDataDir(),
+	//HTTPPort: DefaultHTTPPort,
+	//HTTPModules:      []string{"net", "web3"},
+	//HTTPVirtualHosts: []string{"localhost"},
+	//WSPort:           DefaultWSPort,
+	//WSModules:        []string{"net", "web3"},
+	P2P: p2p.Config{
+		ListenAddr: ":30303",
+		MaxPeers:   25,
+		NAT:        nat.Any(),
+	},
+}
+
+// DefaultDataDir is the default data directory to use for the databases and other
+// persistence requirements.
+func DefaultDataDir() string {
+	// Try to place the data folder in the user's home dir
+	home := homeDir()
+	if home != "" {
+		return filepath.Join(home, ".kardia")
+
+		// TODO: may need to handle non-unix OS.
+	}
+	// As we cannot guess a stable location, return empty and handle later
+	return ""
+}
+
+func homeDir() string {
+	if home := os.Getenv("HOME"); home != "" {
+		return home
+	}
+	if usr, err := user.Current(); err == nil {
+		return usr.HomeDir
+	}
+	return ""
+}

--- a/node/node.go
+++ b/node/node.go
@@ -5,6 +5,8 @@ import (
 	"conceptchain/p2p"
 	"errors"
 	"sync"
+	"conceptchain/p2p/discover"
+	"fmt"
 )
 
 var (
@@ -53,7 +55,21 @@ func (n *Node) Start() error {
 	n.serverConfig.Logger = n.log
 	n.serverConfig.Name = n.config.NodeName()
 	n.serverConfig.PrivateKey = n.config.NodeKey()
-	// TODO: all node list will be empty, start adding peer data to config dir.
+
+	// TODO: use json file in datadir to load the node list
+	var nodes []*discover.Node
+	n.log.Info("Reading peer data")
+	peer, err := discover.ParseNode("enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:3000")
+
+	if err != nil {
+		n.log.Error(err.Error())
+		panic(err)
+	}
+	fmt.Printf("Peer: %s \n", peer)
+	fmt.Printf("Peer incomplete status %t \n", peer.Incomplete())
+	nodes = append(nodes, peer)
+
+	n.serverConfig.StaticNodes = nodes
 	// n.serverConfig.StaticNodes = []
 	// n.serverConfig.TrustedNodes = ...
 	// n.serverConfig.NodeDatabase = ...

--- a/node/node.go
+++ b/node/node.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"sync"
 	"conceptchain/p2p/discover"
-	"fmt"
 )
 
 var (
@@ -58,15 +57,14 @@ func (n *Node) Start() error {
 
 	// TODO: use json file in datadir to load the node list
 	var nodes []*discover.Node
-	n.log.Info("Reading peer data")
 	peer, err := discover.ParseNode("enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:3000")
 
 	if err != nil {
 		n.log.Error(err.Error())
 		panic(err)
 	}
-	fmt.Printf("Peer: %s \n", peer)
-	fmt.Printf("Peer incomplete status %t \n", peer.Incomplete())
+	n.log.Info("Discovered Node:", "discover.node", peer, "incomplete", peer.Incomplete())
+
 	nodes = append(nodes, peer)
 
 	n.serverConfig.StaticNodes = nodes

--- a/node/node_config.go
+++ b/node/node_config.go
@@ -1,0 +1,124 @@
+package node
+
+import (
+	"conceptchain/crypto"
+	"conceptchain/log"
+	"conceptchain/p2p"
+	"crypto/ecdsa"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	datadirPrivateKey      = "nodekey"  // Path within the datadir to the node's private key
+	datadirDefaultKeyStore = "keystore" // Path within the datadir to the keystore
+)
+
+type NodeConfig struct {
+	// Name sets the instance name of the node. It must not contain the / character and is
+	// used in the devp2p node identifier. If no
+	// value is specified, the basename of the current executable is used.
+	Name string `toml:"-"`
+
+	// UserIdent, if set, is used as an additional component in the devp2p node identifier.
+	UserIdent string `toml:",omitempty"`
+
+	// Version should be set to the version number of the program. It is used
+	// in the devp2p node identifier.
+	Version string `toml:"-"`
+
+	// DataDir is the file system folder the node should use for any data storage
+	// requirements. The configured data directory will not be directly shared with
+	// registered services, instead those can use utility methods to create/access
+	// databases or flat files. This enables ephemeral nodes which can fully reside
+	// in memory.
+	DataDir string
+
+	// Configuration of peer-to-peer networking.
+	P2P p2p.Config
+
+	// KeyStoreDir is the file system folder that contains private keys. The directory can
+	// be specified as a relative path, in which case it is resolved relative to the
+	// current directory.
+	//
+	// If KeyStoreDir is empty, the default location is the "keystore" subdirectory of
+	// DataDir. If DataDir is unspecified and KeyStoreDir is empty, an ephemeral directory
+	// is created by New and destroyed when the node is stopped.
+	KeyStoreDir string `toml:",omitempty"`
+}
+
+// Returns the devp2p node identifier.
+func (c *NodeConfig) NodeName() string {
+	// TODO: add version & OS to name
+	return c.name()
+}
+
+// Retrieves the currently configured private key of the node, checking
+// first any manually set key, falling back to the one found in the configured
+// data folder. If no key can be found, a new one is generated.
+func (c *NodeConfig) NodeKey() *ecdsa.PrivateKey {
+	// Use any specifically configured key.
+	if c.P2P.PrivateKey != nil {
+		return c.P2P.PrivateKey
+	}
+	// Generate ephemeral key if no datadir is being used.
+	if c.DataDir == "" {
+		key, err := crypto.GenerateKey()
+		if err != nil {
+			log.Crit(fmt.Sprintf("Failed to generate ephemeral node key: %v", err))
+		}
+		return key
+	}
+
+	keyfile := c.resolvePath(datadirPrivateKey)
+	if key, err := crypto.LoadECDSA(keyfile); err == nil {
+		return key
+	}
+	// No persistent key found, generate and store a new one.
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		log.Crit(fmt.Sprintf("Failed to generate node key: %v", err))
+	}
+	instanceDir := filepath.Join(c.DataDir, c.name())
+	if err := os.MkdirAll(instanceDir, 0700); err != nil {
+		log.Error(fmt.Sprintf("Failed to persist node key: %v", err))
+		return key
+	}
+	keyfile = filepath.Join(instanceDir, datadirPrivateKey)
+	if err := crypto.SaveECDSA(keyfile, key); err != nil {
+		log.Error(fmt.Sprintf("Failed to persist node key: %v", err))
+	}
+	return key
+}
+
+// Return saved name or executable file name.
+func (c *NodeConfig) name() string {
+	if c.Name == "" {
+		progname := strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+		if progname == "" {
+			panic("empty executable name, set Config.Name")
+		}
+		return progname
+	}
+	return c.Name
+}
+
+func (c *NodeConfig) instanceDir() string {
+	if c.DataDir == "" {
+		return ""
+	}
+	return filepath.Join(c.DataDir, c.name())
+}
+
+// Resolves path in the instance directory.
+func (c *NodeConfig) resolvePath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if c.DataDir == "" {
+		return ""
+	}
+	return filepath.Join(c.instanceDir(), path)
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,0 +1,45 @@
+package node
+
+import (
+	"conceptchain/crypto"
+	"conceptchain/p2p"
+	"testing"
+)
+
+var (
+	testNodeKey, _ = crypto.GenerateKey()
+)
+
+func testNodeConfig() *NodeConfig {
+	return &NodeConfig{
+		Name: "test node",
+		P2P:  p2p.Config{PrivateKey: testNodeKey},
+	}
+}
+
+// Tests that an empty protocol stack can be started, restarted and stopped.
+func TestNodeLifeCycle(t *testing.T) {
+	node, err := NewNode(testNodeConfig())
+	if err != nil {
+		t.Fatalf("fail when create node: %v", err)
+	}
+	// Tests stopping node that not running.
+	if err := node.Stop(); err != ErrNodeStopped {
+		t.Fatalf("unexpected stop error: %v instead of %v", err, ErrNodeStopped)
+	}
+
+	// Tests starting node 2 times
+	if err := node.Start(); err != nil {
+		t.Fatalf("fail when start node: %v", err)
+	}
+	if err := node.Start(); err != ErrNodeRunning {
+		t.Fatalf("unexpected start error: %v instead of %v ", err, ErrNodeRunning)
+	}
+	// Tests stopping node 2 times
+	if err := node.Stop(); err != nil {
+		t.Fatalf("fail when stop node: %v", err)
+	}
+	if err := node.Stop(); err != ErrNodeStopped {
+		t.Fatalf("unexpected stop error: %v instead of %v ", err, ErrNodeStopped)
+	}
+}


### PR DESCRIPTION
Optional argument to setup a static peer through enode URL when running a node
Static peer is permanently connected, attempt reconnect if fail.
Started node run permanently until getting killed, display peer count every 10 secs.